### PR TITLE
Trying to fix a non-existent HEAD

### DIFF
--- a/apps/gitrekt/c_src/geef.c
+++ b/apps/gitrekt/c_src/geef.c
@@ -313,6 +313,7 @@ static ErlNifFunc geef_funcs[] =
 	{"repository_get_odb", 1, geef_repository_odb, 0},
 	{"repository_get_index", 1, geef_repository_index, 0},
 	{"repository_get_config", 1, geef_repository_config, 0},
+        {"repository_set_head", 2, geef_repository_set_head, 0},
 	{"odb_object_hash", 2, geef_odb_hash, 0},
 	{"odb_object_exists?", 2, geef_odb_exists, 0},
 	{"odb_read", 2, geef_odb_read, 0},

--- a/apps/gitrekt/c_src/repository.c
+++ b/apps/gitrekt/c_src/repository.c
@@ -239,3 +239,27 @@ geef_repository_index(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 
 	return enif_make_tuple2(env, atoms.ok, term_index);
 }
+
+ERL_NIF_TERM
+geef_repository_set_head(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+	int error;
+	geef_repository *repo;
+        ErlNifBinary bin;
+
+	if (!enif_get_resource(env, argv[0], geef_repository_type, (void **)&repo))
+                return enif_make_badarg(env);
+
+	if (!enif_inspect_binary(env, argv[1], &bin))
+                return enif_make_badarg(env);
+
+        if (!geef_terminate_binary(&bin))
+                return geef_oom(env);
+
+        error = git_repository_set_head(repo->repo, (char *)bin.data);
+        enif_release_binary(&bin);
+        if (error < 0)
+            return geef_error_struct(env, error);
+
+	return atoms.ok;
+}

--- a/apps/gitrekt/c_src/repository.h
+++ b/apps/gitrekt/c_src/repository.h
@@ -16,6 +16,7 @@ ERL_NIF_TERM geef_repository_is_empty(ErlNifEnv *env, int argc, const ERL_NIF_TE
 ERL_NIF_TERM geef_repository_odb(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM geef_repository_index(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM geef_repository_config(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM geef_repository_set_head(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 void geef_repository_free(ErlNifEnv *env, void *cd);
 

--- a/apps/gitrekt/lib/gitrekt/git.ex
+++ b/apps/gitrekt/lib/gitrekt/git.ex
@@ -380,6 +380,14 @@ defmodule GitRekt.Git do
   end
 
   @doc """
+  Make the `repo` HEAD point to the specified reference.
+  """
+  @spec repository_set_head(repo, binary) :: :ok | {:error, term}
+  def repository_set_head(_repo, _refname) do
+    raise Code.LoadError, file: nif_path() <> ".so"
+  end
+
+  @doc """
   Initializes a new repository at the given `path`.
   """
   @spec repository_init(Path.t, boolean) :: {:ok, repo} | {:error, term}


### PR DESCRIPTION
Because the default branch of some recently new repository is `main` now, but when you create a new repository and do the first push, the HEAD is still points to to `refs/head/master`.

So when you access the repository on the page that was just pushed with the default branch of main, it will trigger an error that the `refs/heads/master` was not found.

This PR tries to fix the problem by setting the first branch in the branch list to HEAD if the current HEAD does not exist.