### PR TITLE
Feat show submodule entry info.

### DIFF
--- a/apps/gitgud_web/lib/gitgud_web/live/tree_browser_live.ex
+++ b/apps/gitgud_web/lib/gitgud_web/live/tree_browser_live.ex
@@ -14,7 +14,7 @@ defmodule GitGud.Web.TreeBrowserLive do
   alias GitGud.UserQuery
   alias GitGud.RepoQuery
 
-  import GitRekt.Git, only: [oid_fmt: 1]
+  import GitRekt.Git, only: [oid_fmt: 1, oid_fmt_short: 1]
 
   import GitGud.Web.CodebaseView
 

--- a/apps/gitgud_web/lib/gitgud_web/live/tree_browser_live.html.heex
+++ b/apps/gitgud_web/lib/gitgud_web/live/tree_browser_live.html.heex
@@ -149,6 +149,9 @@
                   <span class="icon"><i class="fa fa-file"></i></span>
                   <span><%= tree_entry.name %></span>
                 <% end %>
+              <% :commit -> %>
+                <span class="icon"><i class="fa fa-folder-plus"></i></span>
+                <span><%= "#{tree_entry.name} @ #{oid_fmt_short(tree_entry.oid)}" %></span>
             <% end %>
           </td>
           <td class="is-fullwidth">


### PR DESCRIPTION
Now, if the repository contains sub-modules, it will give an error, when rendering the repository tree list.

Here are logs
```
git-frank    | 02:50:35.601 [info]  Sent 500 in 4ms
git-frank    | 
git-frank    | 02:50:35.601 [error] #PID<0.18569.0> running GitGud.Web.Endpoint (connection #PID<0.18567.0>, stream id 1) terminated
git-frank    | Server: 175.178.76.69:4000 (http)
git-frank    | Request: GET /edmondfrank/CloudBackup
git-frank    | ** (exit) an exception was raised:
git-frank    |     ** (CaseClauseError) no case clause matching: :commit
git-frank    |         (gitgud_web 0.3.9) lib/gitgud_web/live/tree_browser_live.html.heex:141: anonymous fn/3 in GitGud.Web.TreeBrowserLive.render/1
git-frank    |         (elixir 1.13.0) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
git-frank    |         (gitgud_web 0.3.9) lib/gitgud_web/live/tree_browser_live.html.heex:138: anonymous fn/2 in GitGud.Web.TreeBrowserLive.render/1
git-frank    |         (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:387: Phoenix.LiveView.Diff.traverse/7
git-frank    |         (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:521: anonymous fn/4 in Phoenix.LiveView.Diff.traverse_dynamic/7
git-frank    |         (elixir 1.13.0) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
git-frank    |         (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:387: Phoenix.LiveView.Diff.traverse/7
git-frank    |         (phoenix_live_view 0.18.2) lib/phoenix_live_view/diff.ex:138: Phoenix.LiveView.Diff.render/3
```
After the repair, the repair result is as shown in the figure.
![image](https://github.com/redrabbit/git.limo/assets/13914416/264e506c-fb39-483f-b264-92edbc6e77df)
